### PR TITLE
Correct Data Types

### DIFF
--- a/value.go
+++ b/value.go
@@ -326,7 +326,8 @@ func init() {
 	// float types
 	RegisterStringConversion(defaultFloatType, stringToFloat)
 	RegisterStringConversion(xsd.Float, stringToFloat)
-	RegisterStringConversion(schema.Number, stringToInt)
+	RegisterStringConversion(schema.Float, stringToFloat)
+	RegisterStringConversion(schema.Number, stringToFloat)
 	// time types
 	RegisterStringConversion(defaultTimeType, stringToTime)
 	RegisterStringConversion(xsd.DateTime, stringToTime)

--- a/value.go
+++ b/value.go
@@ -320,6 +320,7 @@ func init() {
 	RegisterStringConversion(defaultIntType, stringToInt)
 	RegisterStringConversion(xsd.Int, stringToInt)
 	RegisterStringConversion(xsd.Long, stringToInt)
+	RegisterStringConversion(schema.Integer, stringToInt)
 	// bool types
 	RegisterStringConversion(defaultBoolType, stringToBool)
 	RegisterStringConversion(schema.Boolean, stringToBool)

--- a/value.go
+++ b/value.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cayleygraph/quad/voc"
 	"github.com/cayleygraph/quad/voc/schema"
+	"github.com/cayleygraph/quad/voc/xsd"
 )
 
 func IsValidValue(v Value) bool {
@@ -306,32 +307,30 @@ func (s BNode) Native() interface{} { return s }
 // specific IRI type to their native equivalents.
 type StringConversion func(string) (Value, error)
 
+// Following the JSON-LD specification: https://w3c.github.io/json-ld-syntax/#conversion-of-native-data-types
 const (
-	nsXSD = `http://www.w3.org/2001/XMLSchema#`
-)
-
-// TODO(dennwc): make these configurable
-const (
-	defaultIntType   IRI = schema.Integer
-	defaultFloatType IRI = schema.Float
-	defaultBoolType  IRI = schema.Boolean
-	defaultTimeType  IRI = schema.DateTime
+	defaultIntType   IRI = xsd.Integer
+	defaultFloatType IRI = xsd.Double
+	defaultBoolType  IRI = xsd.Boolean
+	defaultTimeType  IRI = xsd.DateTime
 )
 
 func init() {
 	// int types
 	RegisterStringConversion(defaultIntType, stringToInt)
-	RegisterStringConversion(nsXSD+`integer`, stringToInt)
-	RegisterStringConversion(nsXSD+`long`, stringToInt)
+	RegisterStringConversion(xsd.Int, stringToInt)
+	RegisterStringConversion(xsd.Long, stringToInt)
 	// bool types
 	RegisterStringConversion(defaultBoolType, stringToBool)
-	RegisterStringConversion(nsXSD+`boolean`, stringToBool)
+	RegisterStringConversion(schema.Boolean, stringToBool)
 	// float types
 	RegisterStringConversion(defaultFloatType, stringToFloat)
-	RegisterStringConversion(nsXSD+`double`, stringToFloat)
+	RegisterStringConversion(xsd.Float, stringToFloat)
+	RegisterStringConversion(schema.Number, stringToInt)
 	// time types
 	RegisterStringConversion(defaultTimeType, stringToTime)
-	RegisterStringConversion(nsXSD+`dateTime`, stringToTime)
+	RegisterStringConversion(xsd.DateTime, stringToTime)
+	RegisterStringConversion(schema.DateTime, stringToTime)
 }
 
 var knownConversions = make(map[IRI]StringConversion)

--- a/voc/xsd/xsd.go
+++ b/voc/xsd/xsd.go
@@ -1,0 +1,37 @@
+// Package xsd contains constants of the W3C XML Schema Definition Language https://www.w3.org/TR/xmlschema11-1/
+package xsd
+
+import "github.com/cayleygraph/quad/voc"
+
+func init() {
+	voc.RegisterPrefix(Prefix, NS)
+}
+
+const (
+	NS     = "http://www.w3.org/2001/XMLSchema#"
+	Prefix = "xsd"
+)
+
+// Base types
+const (
+	// Boolean represents the values of two-valued logic.
+	Boolean = Prefix + `boolean`
+	// String represents character strings
+	String = Prefix + `string`
+	// Double datatype is patterned after the IEEE double-precision 64-bit floating point datatype [IEEE 754-2008]. Each floating point datatype has a value space that is a subset of the rational numbers.  Floating point numbers are often used to approximate arbitrary real numbers.
+	Double = Prefix + `double`
+	// DateTime represents instants of time, optionally marked with a particular time zone offset.  Values representing the same instant but having different time zone offsets are equal but not identical.
+	DateTime = Prefix + `dateTime`
+)
+
+// Extra numeric types
+const (
+	// Integer is derived from decimal by fixing the value of fractionDigits to be 0 and disallowing the trailing decimal point. This results in the standard mathematical concept of the integer numbers.
+	Integer = Prefix + `integer`
+	// Long is derived from integer by setting the value of maxInclusive to be 9223372036854775807 and minInclusive to be -9223372036854775808. The base type of long is integer.
+	Long = Prefix + `long`
+	// Int is derived from long by setting the value of maxInclusive to be 2147483647 and minInclusive to be -2147483648.
+	Int = Prefix + `int`
+	// Float datatype is patterned after the IEEE single-precision 32-bit floating point datatype
+	Float = Prefix + `float`
+)


### PR DESCRIPTION
Currently, schema.org's data types are used as primitive types. Because of that, JSON-LD documents are produced. This PR fixes it by using XSD for primitive data types.
 - Use XSD for default data types as defined in the JSON-LD specification
 - Create an XSD package with documentation