### PR TITLE
refactor: add context parameters to inner functions

### DIFF
--- a/dot/dot.go
+++ b/dot/dot.go
@@ -2,6 +2,7 @@
 package dot
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -43,7 +44,7 @@ func (w *Writer) writeString(s string) {
 	_, w.err = w.w.Write([]byte(s))
 }
 
-func (w *Writer) WriteQuad(q quad.Quad) error {
+func (w *Writer) WriteQuad(ctx context.Context, q quad.Quad) error {
 	if w.err != nil {
 		return w.err
 	} else if !q.IsValid() {
@@ -66,9 +67,9 @@ func (w *Writer) WriteQuad(q quad.Quad) error {
 	return w.err
 }
 
-func (w *Writer) WriteQuads(buf []quad.Quad) (int, error) {
+func (w *Writer) WriteQuads(ctx context.Context, buf []quad.Quad) (int, error) {
 	for i, q := range buf {
-		if err := w.WriteQuad(q); err != nil {
+		if err := w.WriteQuad(ctx, q); err != nil {
 			return i, err
 		}
 	}

--- a/dot/dot_test.go
+++ b/dot/dot_test.go
@@ -2,6 +2,7 @@ package dot_test
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/cayleygraph/quad"
@@ -54,10 +55,11 @@ var testData = []struct {
 
 func TestWriter(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
+	ctx := context.Background()
 	for _, c := range testData {
 		buf.Reset()
 		w := dot.NewWriter(buf)
-		n, err := quad.Copy(w, quad.NewReader(c.quads))
+		n, err := quad.Copy(ctx, w, quad.NewReader(c.quads))
 		if err != nil {
 			t.Fatalf("write failed after %d quads: %v", n, err)
 		}

--- a/formats.go
+++ b/formats.go
@@ -1,6 +1,7 @@
 package quad
 
 import (
+	"context"
 	"fmt"
 	"io"
 )
@@ -22,7 +23,7 @@ type Format struct {
 	// MarshalValue encodes one value in specific a format.
 	MarshalValue func(v Value) ([]byte, error)
 	// UnmarshalValue decodes a value from specific format.
-	UnmarshalValue func(b []byte) (Value, error)
+	UnmarshalValue func(ctx context.Context, b []byte) (Value, error)
 }
 
 var (

--- a/gml/gml.go
+++ b/gml/gml.go
@@ -2,6 +2,7 @@
 package gml
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -60,7 +61,7 @@ func escape(s string) string {
 	return `"` + escaper.Replace(s) + `"`
 }
 
-func (w *Writer) WriteQuad(q quad.Quad) error {
+func (w *Writer) WriteQuad(ctx context.Context, q quad.Quad) error {
 	if w.err != nil {
 		return w.err
 	} else if !q.IsValid() {
@@ -83,9 +84,9 @@ func (w *Writer) WriteQuad(q quad.Quad) error {
 	return w.err
 }
 
-func (w *Writer) WriteQuads(buf []quad.Quad) (int, error) {
+func (w *Writer) WriteQuads(ctx context.Context, buf []quad.Quad) (int, error) {
 	for i, q := range buf {
-		if err := w.WriteQuad(q); err != nil {
+		if err := w.WriteQuad(ctx, q); err != nil {
 			return i, err
 		}
 	}

--- a/gml/gml_test.go
+++ b/gml/gml_test.go
@@ -2,6 +2,7 @@ package gml_test
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/cayleygraph/quad"
@@ -53,10 +54,11 @@ graph [ directed 1
 
 func TestWriter(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
+	ctx := context.Background()
 	for _, c := range testData {
 		buf.Reset()
 		w := gml.NewWriter(buf)
-		n, err := quad.Copy(w, quad.NewReader(c.quads))
+		n, err := quad.Copy(ctx, w, quad.NewReader(c.quads))
 		if err != nil {
 			t.Fatalf("write failed after %d quads: %v", n, err)
 		}

--- a/graphml/graphml.go
+++ b/graphml/graphml.go
@@ -2,6 +2,7 @@
 package graphml
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 	"io"
@@ -55,7 +56,7 @@ func (w *Writer) writeNode(s string) int {
 	return i
 }
 
-func (w *Writer) WriteQuad(q quad.Quad) error {
+func (w *Writer) WriteQuad(ctx context.Context, q quad.Quad) error {
 	if w.err != nil {
 		return w.err
 	} else if !q.IsValid() {
@@ -84,9 +85,9 @@ func (w *Writer) WriteQuad(q quad.Quad) error {
 	return w.err
 }
 
-func (w *Writer) WriteQuads(buf []quad.Quad) (int, error) {
+func (w *Writer) WriteQuads(ctx context.Context, buf []quad.Quad) (int, error) {
 	for i, q := range buf {
-		if err := w.WriteQuad(q); err != nil {
+		if err := w.WriteQuad(ctx, q); err != nil {
 			return i, err
 		}
 	}

--- a/graphml/graphml_test.go
+++ b/graphml/graphml_test.go
@@ -2,6 +2,7 @@ package graphml_test
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/cayleygraph/quad"
@@ -58,11 +59,12 @@ var testData = []struct {
 }
 
 func TestWriter(t *testing.T) {
+	ctx := context.Background()
 	buf := bytes.NewBuffer(nil)
 	for _, c := range testData {
 		buf.Reset()
 		w := graphml.NewWriter(buf)
-		n, err := quad.Copy(w, quad.NewReader(c.quads))
+		n, err := quad.Copy(ctx, w, quad.NewReader(c.quads))
 		if err != nil {
 			t.Fatalf("write failed after %d quads: %v", n, err)
 		}

--- a/json/json.go
+++ b/json/json.go
@@ -2,6 +2,7 @@
 package json
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -20,7 +21,7 @@ func init() {
 		MarshalValue: func(v quad.Value) ([]byte, error) {
 			return json.Marshal(quad.ToString(v))
 		},
-		UnmarshalValue: func(b []byte) (quad.Value, error) {
+		UnmarshalValue: func(ctx context.Context, b []byte) (quad.Value, error) {
 			var s *string
 			if err := json.Unmarshal(b, &s); err != nil {
 				return nil, err
@@ -53,7 +54,7 @@ type Reader struct {
 	err   error
 }
 
-func (r *Reader) ReadQuad() (quad.Quad, error) {
+func (r *Reader) ReadQuad(ctx context.Context) (quad.Quad, error) {
 	if r.err != nil {
 		return quad.Quad{}, r.err
 	}
@@ -78,7 +79,7 @@ type StreamReader struct {
 	err error
 }
 
-func (r *StreamReader) ReadQuad() (quad.Quad, error) {
+func (r *StreamReader) ReadQuad(ctx context.Context) (quad.Quad, error) {
 	if r.err != nil {
 		return quad.Quad{}, r.err
 	}
@@ -98,7 +99,7 @@ type Writer struct {
 	closed  bool
 }
 
-func (w *Writer) WriteQuad(q quad.Quad) error {
+func (w *Writer) WriteQuad(ctx context.Context, q quad.Quad) error {
 	if w.closed {
 		return errors.New("closed")
 	} else if !q.IsValid() {
@@ -122,9 +123,9 @@ func (w *Writer) WriteQuad(q quad.Quad) error {
 	return err
 }
 
-func (w *Writer) WriteQuads(buf []quad.Quad) (int, error) {
+func (w *Writer) WriteQuads(ctx context.Context, buf []quad.Quad) (int, error) {
 	for i, q := range buf {
-		if err := w.WriteQuad(q); err != nil {
+		if err := w.WriteQuad(ctx, q); err != nil {
 			return i, err
 		}
 	}
@@ -152,16 +153,16 @@ type StreamWriter struct {
 	enc *json.Encoder
 }
 
-func (w *StreamWriter) WriteQuad(q quad.Quad) error {
+func (w *StreamWriter) WriteQuad(ctx context.Context, q quad.Quad) error {
 	if !q.IsValid() {
 		return quad.ErrInvalid
 	}
 	return w.enc.Encode(q)
 }
 
-func (w *StreamWriter) WriteQuads(buf []quad.Quad) (int, error) {
+func (w *StreamWriter) WriteQuads(ctx context.Context, buf []quad.Quad) (int, error) {
 	for i, q := range buf {
-		if err := w.WriteQuad(q); err != nil {
+		if err := w.WriteQuad(ctx, q); err != nil {
 			return i, err
 		}
 	}

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -16,6 +16,7 @@ package json
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -76,9 +77,10 @@ var readTests = []struct {
 }
 
 func TestReadJSON(t *testing.T) {
+	ctx := context.Background()
 	for _, test := range readTests {
 		qr := NewReader(strings.NewReader(test.input))
-		got, err := quad.ReadAll(qr)
+		got, err := quad.ReadAll(ctx, qr)
 		qr.Close()
 		if fmt.Sprint(err) != fmt.Sprint(test.err) {
 			t.Errorf("Failed to %v with unexpected error, got:%v expected %v", test.message, err, test.err)
@@ -130,11 +132,12 @@ var writeTests = []struct {
 }
 
 func TestWriteJSON(t *testing.T) {
+	ctx := context.Background()
 	buf := bytes.NewBuffer(nil)
 	for _, test := range writeTests {
 		buf.Reset()
 		qw := NewWriter(buf)
-		_, err := quad.Copy(qw, quad.NewReader(test.input))
+		_, err := quad.Copy(ctx, qw, quad.NewReader(test.input))
 		if err != nil {
 			t.Errorf("Failed to %v: %v", test.message, err)
 			continue
@@ -150,6 +153,7 @@ func TestWriteJSON(t *testing.T) {
 }
 
 func TestValueEncoding(t *testing.T) {
+	ctx := context.Background()
 	vals := []quad.Value{
 		quad.String("some val"),
 		quad.IRI("iri"),
@@ -169,7 +173,7 @@ func TestValueEncoding(t *testing.T) {
 		data, err := f.MarshalValue(v)
 		require.NoError(t, err)
 		require.Equal(t, enc[i], string(data), string(data))
-		v2, err := f.UnmarshalValue(data)
+		v2, err := f.UnmarshalValue(ctx, data)
 		require.NoError(t, err)
 		require.Equal(t, v, v2)
 	}

--- a/jsonld/jsonld.go
+++ b/jsonld/jsonld.go
@@ -2,6 +2,7 @@
 package jsonld
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -61,7 +62,7 @@ type Reader struct {
 }
 
 // ReadQuad implements the quad.Reader interface
-func (r *Reader) ReadQuad() (quad.Quad, error) {
+func (r *Reader) ReadQuad(ctx context.Context) (quad.Quad, error) {
 	if r.err != nil {
 		return quad.Quad{}, r.err
 	}
@@ -122,7 +123,7 @@ func (w *Writer) SetLdContext(ctx interface{}) {
 }
 
 // WriteQuad implements quad.Writer
-func (w *Writer) WriteQuad(q quad.Quad) error {
+func (w *Writer) WriteQuad(ctx context.Context, q quad.Quad) error {
 	if !q.IsValid() {
 		return quad.ErrInvalid
 	}
@@ -146,9 +147,9 @@ func (w *Writer) WriteQuad(q quad.Quad) error {
 }
 
 // WriteQuads implements quad.Writer
-func (w *Writer) WriteQuads(buf []quad.Quad) (int, error) {
+func (w *Writer) WriteQuads(ctx context.Context, buf []quad.Quad) (int, error) {
 	for i, q := range buf {
-		if err := w.WriteQuad(q); err != nil {
+		if err := w.WriteQuad(ctx, q); err != nil {
 			return i, err
 		}
 	}

--- a/jsonld/jsonld_test.go
+++ b/jsonld/jsonld_test.go
@@ -2,6 +2,7 @@ package jsonld
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"reflect"
 	"sort"
@@ -79,9 +80,10 @@ func (a ByQuad) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a ByQuad) Less(i, j int) bool { return a[i].NQuad() < a[j].NQuad() }
 
 func TestRead(t *testing.T) {
+	ctx := context.Background()
 	for i, c := range testReadCases {
 		r := NewReader(strings.NewReader(c.data))
-		quads, err := quad.ReadAll(r)
+		quads, err := quad.ReadAll(ctx, r)
 		if err != nil {
 			t.Errorf("case %d failed: %v", i, err)
 		}
@@ -166,11 +168,12 @@ var testWriteCases = []struct {
 
 func TestWrite(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
+	ctx := context.Background()
 	for i, c := range testWriteCases {
 		buf.Reset()
 		w := NewWriter(buf)
 		w.SetLdContext(c.ctx)
-		_, err := quad.Copy(w, quad.NewReader(c.data))
+		_, err := quad.Copy(ctx, w, quad.NewReader(c.data))
 		if err != nil {
 			t.Errorf("case %d failed: %v", i, err)
 		} else if err = w.Close(); err != nil {
@@ -231,16 +234,17 @@ var testRoundtripCases = []struct {
 
 func TestRoundtrip(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
+	ctx := context.Background()
 	for i, c := range testRoundtripCases {
 		buf.Reset()
 		w := NewWriter(buf)
-		_, err := quad.Copy(w, quad.NewReader(c.data))
+		_, err := quad.Copy(ctx, w, quad.NewReader(c.data))
 		if err != nil {
 			t.Errorf("case %d failed: %v", i, err)
 		} else if err = w.Close(); err != nil {
 			t.Errorf("case %d failed: %v", i, err)
 		}
-		arr, err := quad.ReadAll(NewReader(buf))
+		arr, err := quad.ReadAll(ctx, NewReader(buf))
 		sort.Sort(quad.ByQuadString(arr))
 		sort.Sort(quad.ByQuadString(c.data))
 		if err != nil {

--- a/nquads/raw_test.go
+++ b/nquads/raw_test.go
@@ -17,6 +17,7 @@ package nquads
 import (
 	"archive/tar"
 	"compress/gzip"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -448,10 +449,11 @@ func TestParseRaw(t *testing.T) {
 }
 
 func TestRawDecoder(t *testing.T) {
+	ctx := context.Background()
 	dec := NewReader(strings.NewReader(document), true)
 	var n int
 	for {
-		q, err := dec.ReadQuad()
+		q, err := dec.ReadQuad(ctx)
 		if err != nil {
 			if err != io.EOF {
 				t.Fatalf("Failed to read documentRaw: %v", err)
@@ -469,6 +471,7 @@ func TestRawDecoder(t *testing.T) {
 }
 
 func TestRDFWorkingGroupSuitRaw(t *testing.T) {
+	ctx := context.Background()
 	// These tests erroneously pass because the parser does not
 	// perform semantic testing on the URI in the IRIRef as required
 	// by the specification. So, we skip them.
@@ -521,7 +524,7 @@ func TestRDFWorkingGroupSuitRaw(t *testing.T) {
 
 			dec := NewReader(tr, true)
 			for {
-				_, err := dec.ReadQuad()
+				_, err := dec.ReadQuad(ctx)
 				if err == io.EOF {
 					break
 				}

--- a/nquads/typed_test.go
+++ b/nquads/typed_test.go
@@ -17,6 +17,7 @@ package nquads
 import (
 	"archive/tar"
 	"compress/gzip"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -676,10 +677,11 @@ _:100009 </film/performance/actor> </en/larry_fine_1902> .
 `
 
 func TestDecoder(t *testing.T) {
+	ctx := context.Background()
 	dec := NewReader(strings.NewReader(document), false)
 	var n int
 	for {
-		q, err := dec.ReadQuad()
+		q, err := dec.ReadQuad(ctx)
 		if err != nil {
 			if err != io.EOF {
 				t.Fatalf("Failed to read document: %v", err)
@@ -697,6 +699,7 @@ func TestDecoder(t *testing.T) {
 }
 
 func TestRDFWorkingGroupSuit(t *testing.T) {
+	ctx := context.Background()
 	// Tests that are not passable by cquads parsing from the RDF
 	// Working Group Suite:
 	//
@@ -792,7 +795,7 @@ func TestRDFWorkingGroupSuit(t *testing.T) {
 
 			dec := NewReader(tr, false)
 			for {
-				_, err := dec.ReadQuad()
+				_, err := dec.ReadQuad(ctx)
 				if err == io.EOF {
 					break
 				}
@@ -844,6 +847,7 @@ func BenchmarkParser(b *testing.B) {
 }
 
 func TestValueEncoding(t *testing.T) {
+	ctx := context.Background()
 	vals := []quad.Value{
 		quad.String("some val"),
 		quad.IRI("iri"),
@@ -863,7 +867,7 @@ func TestValueEncoding(t *testing.T) {
 		data, err := f.MarshalValue(v)
 		require.NoError(t, err)
 		require.Equal(t, enc[i], string(data), string(data))
-		v2, err := f.UnmarshalValue(data)
+		v2, err := f.UnmarshalValue(ctx, data)
 		require.NoError(t, err)
 		require.Equal(t, v, v2)
 	}

--- a/pquads/pquads.go
+++ b/pquads/pquads.go
@@ -3,6 +3,7 @@ package pquads
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -71,7 +72,7 @@ func NewWriter(w io.Writer, opts *Options) *Writer {
 	})
 	return &Writer{pw: pw, err: err, opts: *opts}
 }
-func (w *Writer) WriteQuad(q quad.Quad) error {
+func (w *Writer) WriteQuad(ctx context.Context, q quad.Quad) error {
 	if w.err != nil {
 		return w.err
 	} else if !q.IsValid() {
@@ -111,9 +112,9 @@ func (w *Writer) WriteQuad(q quad.Quad) error {
 	return w.err
 }
 
-func (w *Writer) WriteQuads(buf []quad.Quad) (int, error) {
+func (w *Writer) WriteQuads(ctx context.Context, buf []quad.Quad) (int, error) {
 	for i, q := range buf {
-		if err := w.WriteQuad(q); err != nil {
+		if err := w.WriteQuad(ctx, q); err != nil {
 			return i, err
 		}
 	}
@@ -181,7 +182,7 @@ func NewReader(r io.Reader, maxSize int) *Reader {
 	}
 	return qr
 }
-func (r *Reader) ReadQuad() (quad.Quad, error) {
+func (r *Reader) ReadQuad(ctx context.Context) (quad.Quad, error) {
 	if r.err != nil {
 		return quad.Quad{}, r.err
 	}
@@ -216,10 +217,10 @@ func (r *Reader) ReadQuad() (quad.Quad, error) {
 	}
 	return q, nil
 }
-func (r *Reader) SkipQuad() error {
+func (r *Reader) SkipQuad(ctx context.Context) error {
 	if !r.opts.Full {
 		// TODO(dennwc): read pb fields as bytes and unmarshal them only if ReadQuad is called
-		_, err := r.ReadQuad()
+		_, err := r.ReadQuad(ctx)
 		return err
 	}
 	r.err = r.pr.SkipMsg()

--- a/pquads/pquads_test.go
+++ b/pquads/pquads_test.go
@@ -2,6 +2,7 @@ package pquads_test
 
 import (
 	"bytes"
+	"context"
 	"reflect"
 	"testing"
 
@@ -72,10 +73,11 @@ func TestPQuads(t *testing.T) {
 			name += " strict"
 		}
 		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
 			for _, c := range testData {
 				buf.Reset()
 				w := pquads.NewWriter(buf, &opts)
-				n, err := quad.Copy(w, quad.NewReader(c.quads))
+				n, err := quad.Copy(ctx, w, quad.NewReader(c.quads))
 				if err != nil {
 					t.Fatalf("write failed after %d quads: %v", n, err)
 				}
@@ -84,7 +86,7 @@ func TestPQuads(t *testing.T) {
 				}
 				t.Log("size:", buf.Len())
 				r := pquads.NewReader(buf, 0)
-				quads, err := quad.ReadAll(r)
+				quads, err := quad.ReadAll(ctx, r)
 				if err != nil {
 					t.Fatalf("read failed: %v", err)
 				}

--- a/pquads/quads.go
+++ b/pquads/quads.go
@@ -1,6 +1,7 @@
 package pquads
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -61,7 +62,7 @@ func MarshalValue(v quad.Value) ([]byte, error) {
 }
 
 // UnmarshalValue is a helper for deserialization of quad.Value.
-func UnmarshalValue(data []byte) (quad.Value, error) {
+func UnmarshalValue(ctx context.Context, data []byte) (quad.Value, error) {
 	if len(data) == 0 {
 		return nil, nil
 	}


### PR DESCRIPTION
Eliminate context.TODO instances and add context parameters to all long-lived operations for code consistency and better behavior when contexts may be canceled in the middle of a long-lived operation.